### PR TITLE
meta: add check for 'llvm-ar' in doctor

### DIFF
--- a/meta/plugins/doctor-cmd.py
+++ b/meta/plugins/doctor-cmd.py
@@ -110,6 +110,9 @@ def doctorCmd(args: Args):
         "clang++", versionExpected=(16,)
     )
     everythingIsOk = everythingIsOk & commandIsAvailable(
+        "llvm-ar", versionExpected=(16,)
+    )
+    everythingIsOk = everythingIsOk & commandIsAvailable(
         "ld.lld", versionExpected=(16,)
     )
     everythingIsOk = everythingIsOk & commandIsAvailable("nasm")


### PR DESCRIPTION
I seen that skift needs 'llvm-ar' to be built.