### PR TITLE
meta: Complete update to cutekit 0.9.x

### DIFF
--- a/meta/plugins/requirements.txt
+++ b/meta/plugins/requirements.txt
@@ -1,2 +1,2 @@
 python-magic ~= 0.4.27
-git+https://github.com/cute-engineering/cutekit.git@0.8.8
+git+https://github.com/cute-engineering/cutekit.git@0.9.1


### PR DESCRIPTION
This change attempts to complete `commit`[09863f2](https://github.com/skift-org/skift/commit/09863f2cb1ea4a80f5d8ba24e96f81c933136c55) which in turn resolves the current issue we have when building on [Ubuntu](https://github.com/skift-org/skift/actions/runs/15946506723/job/44981236094) and [Darwin](https://github.com/skift-org/skift/actions/runs/15946506733/job/44981236095)

>$${\color{orange}Warning:}$$` Plugin meta/plugins/__init__.py loading skipped due to: Expected cutekit version 0.9.0 but found 0.8.8`