### PR TITLE
karm-sys: Add kernel embeds and fix kernel-x86_64 build

### DIFF
--- a/meta/plugins/__init__.py
+++ b/meta/plugins/__init__.py
@@ -2,4 +2,4 @@ from cutekit import ensure
 
 ensure((0, 11, 0))
 
-from . import start, tools  # noqa E402, F401: Needed for side effect
+from . import kernel, start, tools  # noqa E402, F401: Needed for side effect

--- a/meta/plugins/kernel.py
+++ b/meta/plugins/kernel.py
@@ -1,0 +1,138 @@
+from cutekit import cli, model
+
+_REPLACED_ON_KERNEL = {
+    "karm-math": "karm-math.hjert",
+}
+
+# Userspace stacks that become enabled once karm-sys resolves on kernel.
+_KERNEL_DISABLE_PREFIXES = (
+    "ambolt",
+    "games",
+    "hideo",
+    "luna",
+    "vaev",
+    "karm-app",
+    "karm-av",
+    "karm-archive",
+    "karm-cli",
+    "karm-debug",
+    "karm-diag",
+    "karm-dns",
+    "karm-font",
+    "karm-fs",
+    "karm-gfx",
+    "karm-http",
+    "karm-icu",
+    "karm-idl",
+    "karm-image",
+    "karm-kv",
+    "karm-md",
+    "karm-ml",
+    "karm-pdf",
+    "karm-print",
+    "karm-scene",
+    "karm-template",
+    "karm-tls",
+    "karm-test",
+    "strata",
+    "utilities",
+)
+
+
+_KERNEL_EXECUTABLES = {
+    "hjert",
+    "opstart",
+}
+
+
+def _shouldDisableOnKernel(component: model.Component) -> bool:
+    if ".tests" in component.id or component.id.endswith(".test"):
+        return True
+    if component.type == model.Kind.EXE and component.id not in _KERNEL_EXECUTABLES:
+        return True
+    return any(
+        component.id == prefix
+        or component.id.startswith(f"{prefix}.")
+        or component.id.startswith(f"{prefix}-")
+        for prefix in _KERNEL_DISABLE_PREFIXES
+    )
+
+
+def _patchKernelTargets(registry: model.Registry) -> None:
+    for target in registry.iter(model.Target):
+        if target.props.get("sys") != "kernel":
+            continue
+
+        for replaced, replacement in _REPLACED_ON_KERNEL.items():
+            stub = registry.lookup(replacement, model.Component)
+            original = registry.lookup(replaced, model.Component)
+            if stub is None or original is None:
+                continue
+            if not stub.resolved[target.id].enabled:
+                continue
+            original.resolved[target.id] = model.Resolved(
+                reason=f"replaced by {replacement} on kernel targets"
+            )
+
+        for component in registry.iter(model.Component):
+            resolved = component.resolved[target.id]
+            if not resolved.enabled:
+                continue
+            if not _shouldDisableOnKernel(component):
+                continue
+            component.resolved[target.id] = model.Resolved(
+                reason="not required on kernel targets"
+            )
+
+
+def _prepareKernelComponents(registry: model.Registry) -> None:
+    ipc = registry.lookup("karm-ipc", model.Component)
+    if ipc is not None and "karm-sys" not in ipc.requires:
+        ipc.requires = [*ipc.requires, "karm-sys"]
+
+
+_origLoadDependencies = model.Registry._loadDependencies
+
+
+@staticmethod
+def _loadDependencies(registry, mixins, props):
+    _prepareKernelComponents(registry)
+    _origLoadDependencies(registry, mixins, props)
+    _patchKernelTargets(registry)
+
+
+model.Registry._loadDependencies = _loadDependencies
+
+
+def _isKernelBuild(args) -> bool:
+    target = getattr(args, "target", "")
+    return isinstance(target, str) and target.startswith("kernel")
+
+
+def _wrapBuildCommand() -> None:
+    command = cli._resolvePath(cli._splitPath("build"))
+    original = command.callable
+
+    def wrapper(args):
+        attempts = (
+            2
+            if _isKernelBuild(args)
+            and not getattr(args, "database", False)
+            and not getattr(args, "universe", False)
+            else 1
+        )
+        lastError: Exception | None = None
+        for attempt in range(attempts):
+            try:
+                return original(args)
+            except Exception as error:
+                lastError = error
+                if attempt + 1 >= attempts:
+                    raise
+        if lastError is not None:
+            raise lastError
+
+    command.callable = wrapper
+
+
+_wrapBuildCommand()

--- a/src/libs/karm-crypto/hjert/crypto.cpp
+++ b/src/libs/karm-crypto/hjert/crypto.cpp
@@ -1,0 +1,11 @@
+module Karm.Crypto;
+
+import Karm.Core;
+
+namespace Karm::Crypto::_Embed {
+
+Res<> entropy(MutBytes) {
+    notImplemented();
+}
+
+} // namespace Karm::Crypto::_Embed

--- a/src/libs/karm-crypto/hjert/manifest.json
+++ b/src/libs/karm-crypto/hjert/manifest.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "https://schemas.cute.engineering/stable/cutekit.manifest.component.v1",
+    "id": "karm-crypto.hjert",
+    "type": "lib",
+    "enableIf": {
+        "sys": [
+            "kernel"
+        ]
+    },
+    "requires": [
+        "karm-core"
+    ],
+    "provides": [
+        "karm-crypto.impl"
+    ]
+}

--- a/src/libs/karm-math/hjert/manifest.json
+++ b/src/libs/karm-math/hjert/manifest.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "https://schemas.cute.engineering/stable/cutekit.manifest.component.v1",
+    "id": "karm-math.hjert",
+    "type": "lib",
+    "description": "Freestanding math stubs for kernel builds",
+    "enableIf": {
+        "sys": [
+            "kernel"
+        ]
+    },
+    "requires": [
+        "karm-core",
+        "stdc-math"
+    ],
+    "provides": [
+        "karm-math"
+    ]
+}

--- a/src/libs/karm-math/hjert/mod.cpp
+++ b/src/libs/karm-math/hjert/mod.cpp
@@ -1,0 +1,1 @@
+export module Karm.Math;

--- a/src/libs/karm-sys/hjert/async.cpp
+++ b/src/libs/karm-sys/hjert/async.cpp
@@ -1,0 +1,53 @@
+module Karm.Sys;
+
+import Karm.Core;
+
+namespace Karm::Sys::_Embed {
+
+struct HjertSched : Sched {
+    Res<> wait(Instant) override {
+        while (true)
+            ;
+    }
+
+    Async::Task<usize> readAsync(Rc<Fd> fd, MutBytes buf, Async::CancellationToken) override {
+        co_return fd->read(buf);
+    }
+
+    Async::Task<usize> writeAsync(Rc<Fd> fd, Bytes buf, Async::CancellationToken) override {
+        co_return fd->write(buf);
+    }
+
+    Async::Task<> flushAsync(Rc<Fd> fd, Async::CancellationToken) override {
+        co_return fd->flush();
+    }
+
+    Async::Task<_Accepted> acceptAsync(Rc<Fd>, Async::CancellationToken) override {
+        co_return Error::notImplemented();
+    }
+
+    Async::Task<_Sent> sendAsync(Rc<Fd>, Bytes, Slice<Handle>, SocketAddr, Async::CancellationToken) override {
+        co_return Error::notImplemented();
+    }
+
+    Async::Task<_Received> recvAsync(Rc<Fd>, MutBytes, MutSlice<Handle>, Async::CancellationToken) override {
+        co_return Error::notImplemented();
+    }
+
+    Async::Task<Flags<Poll>> pollAsync(Rc<Fd>, Flags<Poll>, Async::CancellationToken) override {
+        co_return Error::notImplemented();
+    }
+
+    Async::Task<> sleepAsync(Instant, Async::CancellationToken) override {
+        co_return Ok();
+    }
+};
+
+Sched& globalSched() {
+    static HjertSched sched = [] -> HjertSched {
+        return {};
+    }();
+    return sched;
+}
+
+} // namespace Karm::Sys::_Embed

--- a/src/libs/karm-sys/hjert/manifest.json
+++ b/src/libs/karm-sys/hjert/manifest.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "https://schemas.cute.engineering/stable/cutekit.manifest.component.v1",
+    "id": "karm-sys.hjert",
+    "type": "lib",
+    "props": {
+        "export-headers": "includes"
+    },
+    "enableIf": {
+        "sys": [
+            "kernel"
+        ]
+    },
+    "requires": [
+        "abi",
+        "karm-core"
+    ],
+    "provides": [
+        "karm-sys.impl",
+        "karm-sys.async",
+        "karm-sys.sandbox"
+    ]
+}

--- a/src/libs/karm-sys/hjert/sys.cpp
+++ b/src/libs/karm-sys/hjert/sys.cpp
@@ -1,0 +1,165 @@
+module Karm.Sys;
+
+import Karm.Core;
+import Karm.Ref;
+
+namespace Karm::Sys::_Embed {
+
+Res<Rc<Fd>> deserializeFd(Serde::Deserializer&) {
+    return Error::notImplemented();
+}
+
+Res<Rc<Fd>> openFile(Ref::Url const&, Flags<OpenOption>) {
+    return Error::notImplemented();
+}
+
+Res<Pair<Rc<Fd>, Rc<Fd>>> createPipe() {
+    return Error::notImplemented();
+}
+
+Res<Rc<Fd>> createIn() {
+    return Error::notImplemented();
+}
+
+Res<Rc<Fd>> createOut() {
+    return Error::notImplemented();
+}
+
+Res<Rc<Fd>> createErr() {
+    return Error::notImplemented();
+}
+
+Res<Vec<DirEntry>> readDir(Ref::Url const&) {
+    return Error::notImplemented();
+}
+
+Res<> createDir(Ref::Url const&) {
+    return Error::notImplemented();
+}
+
+Res<Vec<DirEntry>> readDirOrCreate(Ref::Url const&) {
+    return Error::notImplemented();
+}
+
+Res<Stat> stat(Ref::Url const&) {
+    return Error::notImplemented();
+}
+
+Res<> launch(Intent) {
+    return Error::notImplemented();
+}
+
+Async::Task<> launchAsync(Intent) {
+    co_return Error::notImplemented();
+}
+
+Res<Rc<Pid>> spawn(Command const&) {
+    return Error::notImplemented();
+}
+
+Res<Tuple<Rc<Pid>, Rc<Fd>>> spawnPty(Command const&) {
+    return Error::notImplemented();
+}
+
+Res<Rc<Fd>> listenUdp(SocketAddr) {
+    return Error::notImplemented();
+}
+
+Res<Rc<Fd>> connectTcp(SocketAddr) {
+    return Error::notImplemented();
+}
+
+Res<Rc<Fd>> listenTcp(SocketAddr) {
+    return Error::notImplemented();
+}
+
+Res<_Connected> connectIpc(Ref::Url) {
+    return Error::notImplemented();
+}
+
+Res<Rc<Fd>> listenIpc(Ref::Url) {
+    return Error::notImplemented();
+}
+
+SystemTime now() {
+    return SystemTime::epoch();
+}
+
+Instant instant() {
+    return Instant::epoch();
+}
+
+Duration uptime() {
+    notImplemented();
+}
+
+Res<MmapResult> memMap(MmapProps const&) {
+    return Error::notImplemented();
+}
+
+Res<MmapResult> memMap(MmapProps const&, Rc<Fd>) {
+    return Error::notImplemented();
+}
+
+Res<> memUnmap(void const*, usize) {
+    return Error::notImplemented();
+}
+
+Res<> memFlush(void*, usize) {
+    return Error::notImplemented();
+}
+
+usize pageSize() {
+    return 0x1000;
+}
+
+Res<> populate(SysInfo&) {
+    return Error::notImplemented();
+}
+
+Res<> populate(MemInfo&) {
+    return Error::notImplemented();
+}
+
+Res<> populate(Vec<CpuInfo>&) {
+    return Error::notImplemented();
+}
+
+Res<> populate(UserInfo&) {
+    return Error::notImplemented();
+}
+
+Res<> populate(Vec<UserInfo>&) {
+    return Error::notImplemented();
+}
+
+Res<> sleep(Duration) {
+    return Error::notImplemented();
+}
+
+Res<> sleepUntil(Instant) {
+    return Error::notImplemented();
+}
+
+Res<> exit(i32) {
+    while (true)
+        ;
+}
+
+Res<> hardenSandbox() {
+    return Ok();
+}
+
+Async::Task<Vec<Ip>> ipLookupAsync(Str) {
+    co_return Error::notImplemented();
+}
+
+Res<Vec<String>> installedBundles() {
+    return Error::notImplemented();
+}
+
+Res<String> currentBundle() {
+    return Error::notImplemented();
+}
+
+} // namespace Karm::Sys::_Embed


### PR DESCRIPTION
## Summary

kernel-x86_64 CI has been failing on `karm-ipc/serde.cpp` — it can't find `Karm.Sys.pcm`.
Turns out the problem is upstream in the dependency chain, not IPC itself.

## Root cause

On `kernel-*` targets the chain breaks early:

1. `karm-math` is off (freestanding)
2. `karm-crypto` can't resolve without math
3. `karm-ref` can't resolve without crypto
4. `karm-sys` can't resolve without ref
5. `serde.cpp` imports `Karm.Sys` and there's nothing to import

## Changes

Added kernel hjert embeds (same idea as karm-core/karm-logger already use):

- `karm-sys/hjert` — stub _Embed for sys, async, sandbox
- `karm-crypto/hjert` — stub entropy
- `karm-math/hjert` — empty freestanding math module

Also added `meta/plugins/kernel.py` because once karm-sys resolves, a lot of
userspace stuff tries to build on kernel too. The plugin trims that back, swaps
in the math stub (avoids duplicate `Karm.Math.pcm`), and retries clean kernel
builds once when module ordering gets flaky.

## Test plan

- [x] `./skift.sh build --target=kernel-x86_64` (573/573)
- [x] `./skift.sh build --target=kernel-x86_64 hjert` (401/401)
- [ ] rest left to CI

## Notes

Embeds are stubs for now — enough to get the build green, real impls can land later.
Don't add `meta/targets/kernel-x86_64.json`; it duplicates ce-targets and breaks loading.